### PR TITLE
A much faster self-contained reimplementation of low level routines

### DIFF
--- a/Florence/FiniteElements/Assembly/_Assembly_/_LowLevelAssemblyExplicit_DF_DPF_.h
+++ b/Florence/FiniteElements/Assembly/_Assembly_/_LowLevelAssemblyExplicit_DF_DPF_.h
@@ -1,6 +1,8 @@
 #ifndef _LOWLEVELASSEMBLYDPF__H
 #define _LOWLEVELASSEMBLYDPF__H
 
+
+
 #include "assembly_helper.h"
 #include "_TractionDF_.h"
 #include "_TractionDPF_.h"
@@ -11,6 +13,631 @@
 #include "_IsotropicElectroMechanics_101_.h"
 #include "_IsotropicElectroMechanics_108_.h"
 
+
+#ifndef EXPLICIT_OLD
+
+// Kinematics
+//
+template<int ndim, typename std::enable_if<ndim==2,bool>::type = 0>
+FASTOR_INLINE void KinematicMeasures__(Real *MaterialGradient, Real *current_sp, Real *current_F, Real &detJ,
+    const Real *current_Jm, Real AllGauss_, const Real *LagrangeElemCoords_, const Real *EulerElemCoords_,
+    int ngauss, int nodeperelem, int update)  {
+
+    Real FASTOR_ALIGN ParentGradientX[ndim*ndim];
+    Real FASTOR_ALIGN invParentGradientX[ndim*ndim];
+    Real FASTOR_ALIGN ParentGradientx[ndim*ndim];
+    Real FASTOR_ALIGN invParentGradientx[ndim*ndim];
+    Real FASTOR_ALIGN current_Ft[ndim*ndim];
+
+    _matmul_(ndim,ndim,nodeperelem,current_Jm,LagrangeElemCoords_,ParentGradientX);
+    _matmul_(ndim,ndim,nodeperelem,current_Jm,EulerElemCoords_,ParentGradientx);
+
+    const Real detX = invdet2x2(ParentGradientX,invParentGradientX);
+    const Real detx = invdet2x2(ParentGradientx,invParentGradientx);
+
+    detJ = update==1 ? AllGauss_*fabs(detx) : AllGauss_*fabs(detX);
+
+    _matmul_(ndim,nodeperelem,ndim,invParentGradientX,current_Jm,MaterialGradient);
+    _matmul_(ndim,nodeperelem,ndim,invParentGradientx,current_Jm,current_sp);
+
+    // Compute deformation gradient F
+    _matmul_(ndim,ndim,nodeperelem,MaterialGradient,EulerElemCoords_,current_Ft);
+    Fastor::_transpose<Real,ndim,ndim>(current_Ft,current_F);
+}
+
+template<int ndim, typename std::enable_if<ndim==3,bool>::type = 0>
+FASTOR_INLINE void KinematicMeasures__(Real *MaterialGradient, Real *current_sp, Real *current_F, Real &detJ,
+    const Real *current_Jm, Real AllGauss_, const Real *LagrangeElemCoords_, const Real *EulerElemCoords_,
+    int ngauss, int nodeperelem, int update)  {
+
+    Real FASTOR_ALIGN ParentGradientX[ndim*ndim];
+    Real FASTOR_ALIGN invParentGradientX[ndim*ndim];
+    Real FASTOR_ALIGN ParentGradientx[ndim*ndim];
+    Real FASTOR_ALIGN invParentGradientx[ndim*ndim];
+    Real FASTOR_ALIGN current_Ft[ndim*ndim];
+
+    _matmul_(ndim,ndim,nodeperelem,current_Jm,LagrangeElemCoords_,ParentGradientX);
+    _matmul_(ndim,ndim,nodeperelem,current_Jm,EulerElemCoords_,ParentGradientx);
+
+    const Real detX = invdet3x3(ParentGradientX,invParentGradientX);
+    const Real detx = invdet3x3(ParentGradientx,invParentGradientx);
+
+    detJ = update==1 ? AllGauss_*fabs(detx) : AllGauss_*fabs(detX);
+
+    _matmul_(ndim,nodeperelem,ndim,invParentGradientX,current_Jm,MaterialGradient);
+    _matmul_(ndim,nodeperelem,ndim,invParentGradientx,current_Jm,current_sp);
+
+    // Compute deformation gradient F
+    _matmul_(ndim,ndim,nodeperelem,MaterialGradient,EulerElemCoords_,current_Ft);
+    Fastor::_transpose<Real,ndim,ndim>(current_Ft,current_F);
+}
+// // //
+
+
+
+
+template<Integer ndim>
+void _GlobalAssemblyExplicit_DF_DPF_(const Real *points,
+                        const UInteger* elements,
+                        const Real* Eulerx,
+                        const Real* Eulerp,
+                        const Real* bases,
+                        const Real* Jm,
+                        const Real* AllGauss,
+                        Integer nvar,
+                        Integer ngauss,
+                        Integer nelem,
+                        Integer nodeperelem,
+                        Integer nnode,
+                        Integer H_VoigtSize,
+                        Integer requires_geometry_update,
+                        Real *T,
+                        Real mu,
+                        Real mu1,
+                        Real mu2,
+                        Real mu3,
+                        Real mue,
+                        Real lamb,
+                        Real eps_1,
+                        Real eps_2,
+                        Real eps_3,
+                        Real eps_e,
+                        const Real *anisotropic_orientations,
+                        int material_number,
+                        int formulation_number
+                        );
+
+
+
+template<>
+void _GlobalAssemblyExplicit_DF_DPF_<2>(const Real *points,
+                        const UInteger* elements,
+                        const Real* Eulerx,
+                        const Real* Eulerp,
+                        const Real* bases,
+                        const Real* Jm,
+                        const Real* AllGauss,
+                        Integer nvar,
+                        Integer ngauss,
+                        Integer nelem,
+                        Integer nodeperelem,
+                        Integer nnode,
+                        Integer H_VoigtSize,
+                        Integer requires_geometry_update,
+                        Real *T,
+                        Real mu,
+                        Real mu1,
+                        Real mu2,
+                        Real mu3,
+                        Real mue,
+                        Real lamb,
+                        Real eps_1,
+                        Real eps_2,
+                        Real eps_3,
+                        Real eps_e,
+                        const Real *anisotropic_orientations,
+                        int material_number,
+                        int formulation_number
+                        ) {
+
+    constexpr Integer ndim = 2;
+    Integer ndof = nvar*nodeperelem;
+
+    Real *LagrangeElemCoords        = allocate<Real>(nodeperelem*ndim);
+    Real *EulerElemCoords           = allocate<Real>(nodeperelem*ndim);
+    Real *ElectricPotentialElem     = allocate<Real>(nodeperelem);
+
+    Real *current_Jm                = allocate<Real>(nodeperelem*ndim);
+    Real *MaterialGradient          = allocate<Real>(ndim*nodeperelem);
+    Real *SpatialGradient           = allocate<Real>(nodeperelem*ndim);
+    Real detJ                       = 0;
+
+    Real FASTOR_ALIGN F[ndim*ndim];
+    Real FASTOR_ALIGN ElectricFieldx[ndim];
+    Tensor<Real,ndim> D;
+    Tensor<Real,ndim,ndim> stress;
+
+    Real *local_traction            = allocate<Real>(ndof);
+    Real *traction                  = allocate<Real>(ndof);
+
+
+    auto mat_obj0 = _NeoHookean_2_<Real>(mu,lamb);
+    auto mat_obj1 = _MooneyRivlin_0_<Real>(mu1,mu2,lamb);
+    auto mat_obj2 = _ExplicitMooneyRivlin_0_<Real>(mu1,mu2,lamb);
+    auto mat_obj3 = _IsotropicElectroMechanics_101_<Real>(mu,lamb,eps_1);
+    auto mat_obj4 = _IsotropicElectroMechanics_108_<Real>(mu1,mu2,lamb,eps_2);
+
+
+    // LOOP OVER ELEMETNS
+    for (Integer elem=0; elem < nelem; ++elem) {
+
+        // GET THE FIELDS AT THE ELEMENT LEVEL
+        for (Integer i=0; i<nodeperelem; ++i) {
+            const Integer inode = elements[elem*nodeperelem+i];
+
+            LagrangeElemCoords[i*2+0] = points[inode*2+0];
+            LagrangeElemCoords[i*2+1] = points[inode*2+1];
+
+            EulerElemCoords[i*2+0] = Eulerx[inode*2+0];
+            EulerElemCoords[i*2+1] = Eulerx[inode*2+1];
+
+            ElectricPotentialElem[i] = Eulerp[inode];
+        }
+
+        std::fill(traction,traction+ndof,0.);
+
+        for (int g=0; g<ngauss; ++g) {
+
+            for (int j=0; j<nodeperelem; ++j) {
+                current_Jm[j] = Jm[j*ngauss+g];
+                current_Jm[nodeperelem+j] = Jm[ngauss*nodeperelem+j*ngauss+g];
+            }
+
+
+            // COMPUTE KINEMATIC MEASURES
+            std::fill(F,F+ndim*ndim,0.);
+            std::fill(MaterialGradient,MaterialGradient+nodeperelem*ndim,0.);
+            std::fill(SpatialGradient,SpatialGradient+nodeperelem*ndim,0.);
+
+            KinematicMeasures__<2>(  MaterialGradient,
+                                    SpatialGradient,
+                                    F,
+                                    detJ,
+                                    current_Jm,
+                                    AllGauss[g],
+                                    LagrangeElemCoords,
+                                    EulerElemCoords,
+                                    ngauss,
+                                    nodeperelem,
+                                    requires_geometry_update
+                                    );
+
+
+            // COMPUTE ELECTRIC FIELD
+            Real iE0 = 0, iE1 = 0;
+            for (Integer j=0; j<nodeperelem; ++j) {
+                const Real potE = ElectricPotentialElem[j];
+                iE0 += SpatialGradient[j]*potE;
+                iE1 += SpatialGradient[nodeperelem+j]*potE;
+            }
+            ElectricFieldx[0] = -iE0;
+            ElectricFieldx[1] = -iE1;
+
+
+            // COMPUTE KINETIC MEASURES
+            if (material_number==0) {
+                std::tie(stress,std::ignore) = mat_obj0.template _KineticMeasures_<Real,ndim>(F);
+            }
+            else if (material_number==1) {
+                std::tie(stress,std::ignore) = mat_obj1.template _KineticMeasures_<Real,ndim>(F);
+            }
+            else if (material_number==2) {
+                stress = mat_obj2.template _KineticMeasures_<Real,ndim>(F);
+            }
+            else if (material_number==3) {
+                std::tie(D,stress,std::ignore) = mat_obj3.template _KineticMeasures_<Real,ndim>(F,ElectricFieldx);
+            }
+            else if (material_number==4) {
+                std::tie(D,stress,std::ignore) = mat_obj4.template _KineticMeasures_<Real,ndim>(F,ElectricFieldx);
+            }
+
+
+            // COMPUTE TRACTION
+            if (formulation_number == 0) {
+
+                const Real s11 = stress(0,0);
+                const Real s12 = stress(0,1);
+                const Real s22 = stress(1,1);
+
+                for (int i=0; i<nodeperelem; ++i) {
+                    const Real a0 = SpatialGradient[i];
+                    const Real a1 = SpatialGradient[nodeperelem+i];
+                    local_traction[2*i]   = a0*s11 + a1*s12;
+                    local_traction[2*i+1] = a0*s12 + a1*s22;
+                }
+            }
+            else if (formulation_number == 1) {
+
+                const Real s11 = stress(0,0);
+                const Real s12 = stress(0,1);
+                const Real s22 = stress(1,1);
+
+                const Real d1  = D(0);
+                const Real d2  = D(1);
+
+                for (int i=0; i<nodeperelem; ++i) {
+                    const Real a0 = SpatialGradient[i];
+                    const Real a1 = SpatialGradient[nodeperelem+i];
+                    local_traction[3*i]   = a0*s11 + a1*s12;
+                    local_traction[3*i+1] = a0*s12 + a1*s22;
+                    local_traction[3*i+2] = a0*d1 + a1*d2;
+                }
+            }
+
+            for (int i=0; i<ndof; ++i) {
+                traction[i] += local_traction[i]*detJ;
+            }
+        }
+
+
+        // ASSEMBLE TRACTIONS
+        for (Integer i = 0; i<nodeperelem; ++i) {
+            UInteger T_idx = elements[elem*nodeperelem+i]*nvar;
+            for (Integer iterator = 0; iterator < nvar; ++iterator) {
+                T[T_idx+iterator] += traction[i*nvar+iterator];
+            }
+        }
+
+    }
+
+
+    deallocate(LagrangeElemCoords);
+    deallocate(EulerElemCoords);
+    deallocate(ElectricPotentialElem);
+    deallocate(current_Jm);
+    deallocate(MaterialGradient);
+    deallocate(SpatialGradient);
+    deallocate(local_traction);
+    deallocate(traction);
+}
+
+
+
+template<>
+void _GlobalAssemblyExplicit_DF_DPF_<3>(const Real *points,
+                        const UInteger* elements,
+                        const Real* Eulerx,
+                        const Real* Eulerp,
+                        const Real* bases,
+                        const Real* Jm,
+                        const Real* AllGauss,
+                        Integer nvar,
+                        Integer ngauss,
+                        Integer nelem,
+                        Integer nodeperelem,
+                        Integer nnode,
+                        Integer H_VoigtSize,
+                        Integer requires_geometry_update,
+                        Real *T,
+                        Real mu,
+                        Real mu1,
+                        Real mu2,
+                        Real mu3,
+                        Real mue,
+                        Real lamb,
+                        Real eps_1,
+                        Real eps_2,
+                        Real eps_3,
+                        Real eps_e,
+                        const Real *anisotropic_orientations,
+                        int material_number,
+                        int formulation_number
+                        ) {
+
+    constexpr Integer ndim = 3;
+    Integer ndof = nvar*nodeperelem;
+
+    Real *LagrangeElemCoords        = allocate<Real>(nodeperelem*ndim);
+    Real *EulerElemCoords           = allocate<Real>(nodeperelem*ndim);
+    Real *ElectricPotentialElem     = allocate<Real>(nodeperelem);
+
+    Real *current_Jm                = allocate<Real>(nodeperelem*ndim);
+    Real *MaterialGradient          = allocate<Real>(ndim*nodeperelem);
+    Real *SpatialGradient           = allocate<Real>(nodeperelem*ndim);
+    Real detJ                       = 0;
+
+    Real FASTOR_ALIGN F[ndim*ndim];
+    Real FASTOR_ALIGN ElectricFieldx[ndim];
+    Tensor<Real,ndim> D;
+    Tensor<Real,ndim,ndim> stress;
+
+    Real *local_traction            = allocate<Real>(ndof);
+    Real *traction                  = allocate<Real>(ndof);
+
+
+    auto mat_obj0 = _NeoHookean_2_<Real>(mu,lamb);
+    auto mat_obj1 = _MooneyRivlin_0_<Real>(mu1,mu2,lamb);
+    auto mat_obj2 = _ExplicitMooneyRivlin_0_<Real>(mu1,mu2,lamb);
+    auto mat_obj3 = _IsotropicElectroMechanics_101_<Real>(mu,lamb,eps_1);
+    auto mat_obj4 = _IsotropicElectroMechanics_108_<Real>(mu1,mu2,lamb,eps_2);
+
+
+    // LOOP OVER ELEMETNS
+    for (Integer elem=0; elem < nelem; ++elem) {
+
+        // GET THE FIELDS AT THE ELEMENT LEVEL
+        for (Integer i=0; i<nodeperelem; ++i) {
+            const Integer inode = elements[elem*nodeperelem+i];
+
+            LagrangeElemCoords[i*3+0] = points[inode*3+0];
+            LagrangeElemCoords[i*3+1] = points[inode*3+1];
+            LagrangeElemCoords[i*3+2] = points[inode*3+2];
+
+            EulerElemCoords[i*3+0] = Eulerx[inode*3+0];
+            EulerElemCoords[i*3+1] = Eulerx[inode*3+1];
+            EulerElemCoords[i*3+2] = Eulerx[inode*3+2];
+
+            ElectricPotentialElem[i] = Eulerp[inode];
+        }
+
+        std::fill(traction,traction+ndof,0.);
+
+        for (int g=0; g<ngauss; ++g) {
+
+            for (int j=0; j<nodeperelem; ++j) {
+                current_Jm[j] = Jm[j*ngauss+g];
+                current_Jm[nodeperelem+j] = Jm[ngauss*nodeperelem+j*ngauss+g];
+                current_Jm[2*nodeperelem+j] = Jm[2*ngauss*nodeperelem+j*ngauss+g];
+            }
+
+
+            // COMPUTE KINEMATIC MEASURES
+            std::fill(F,F+ndim*ndim,0.);
+            std::fill(MaterialGradient,MaterialGradient+nodeperelem*ndim,0.);
+            std::fill(SpatialGradient,SpatialGradient+nodeperelem*ndim,0.);
+
+            KinematicMeasures__<3>(  MaterialGradient,
+                                    SpatialGradient,
+                                    F,
+                                    detJ,
+                                    current_Jm,
+                                    AllGauss[g],
+                                    LagrangeElemCoords,
+                                    EulerElemCoords,
+                                    ngauss,
+                                    nodeperelem,
+                                    requires_geometry_update
+                                    );
+
+
+            // COMPUTE ELECTRIC FIELD
+            Real iE0 = 0, iE1 = 0, iE2 = 0;
+            for (Integer j=0; j<nodeperelem; ++j) {
+                const Real potE = ElectricPotentialElem[j];
+                iE0 += SpatialGradient[j]*potE;
+                iE1 += SpatialGradient[nodeperelem+j]*potE;
+                iE2 += SpatialGradient[2*nodeperelem+j]*potE;
+            }
+            ElectricFieldx[0] = -iE0;
+            ElectricFieldx[1] = -iE1;
+            ElectricFieldx[2] = -iE2;
+
+
+            // COMPUTE KINETIC MEASURES
+            if (material_number==0) {
+                std::tie(stress,std::ignore) = mat_obj0.template _KineticMeasures_<Real,ndim>(F);
+            }
+            else if (material_number==1) {
+                std::tie(stress,std::ignore) = mat_obj1.template _KineticMeasures_<Real,ndim>(F);
+            }
+            else if (material_number==2) {
+                stress = mat_obj2.template _KineticMeasures_<Real,ndim>(F);
+            }
+            else if (material_number==3) {
+                std::tie(D,stress,std::ignore) = mat_obj3.template _KineticMeasures_<Real,ndim>(F,ElectricFieldx);
+            }
+            else if (material_number==4) {
+                std::tie(D,stress,std::ignore) = mat_obj4.template _KineticMeasures_<Real,ndim>(F,ElectricFieldx);
+            }
+
+            if (formulation_number == 0) {
+
+                const Real s11 = stress(0,0);
+                const Real s12 = stress(0,1);
+                const Real s13 = stress(0,2);
+                const Real s22 = stress(1,1);
+                const Real s23 = stress(1,2);
+                const Real s33 = stress(2,2);
+
+                for (int i=0; i<nodeperelem; ++i) {
+
+                    const Real a0 = SpatialGradient[i];
+                    const Real a1 = SpatialGradient[nodeperelem+i];
+                    const Real a2 = SpatialGradient[2*nodeperelem+i];
+
+                    local_traction[3*i]   = a0*s11 + a1*s12 + a2*s13;
+                    local_traction[3*i+1] = a0*s12 + a1*s22 + a2*s23;
+                    local_traction[3*i+2] = a0*s13 + a1*s23 + a2*s33;
+                }
+            }
+            else if (formulation_number == 1) {
+
+                const Real s11 = stress(0,0);
+                const Real s12 = stress(0,1);
+                const Real s13 = stress(0,2);
+                const Real s22 = stress(1,1);
+                const Real s23 = stress(1,2);
+                const Real s33 = stress(2,2);
+
+                const Real d1  = D(0);
+                const Real d2  = D(1);
+                const Real d3  = D(2);
+
+                for (int i=0; i<nodeperelem; ++i) {
+
+                    const Real a0 = SpatialGradient[i];
+                    const Real a1 = SpatialGradient[nodeperelem+i];
+                    const Real a2 = SpatialGradient[2*nodeperelem+i];
+
+                    local_traction[4*i]   = a0*s11 + a1*s12 + a2*s13;
+                    local_traction[4*i+1] = a0*s12 + a1*s22 + a2*s23;
+                    local_traction[4*i+2] = a0*s13 + a1*s23 + a2*s33;
+                    local_traction[4*i+3] = a0*d1 + a1*d2 + a2*d3;
+                }
+            }
+
+            for (int i=0; i<ndof; ++i) {
+                traction[i] += local_traction[i]*detJ;
+            }
+
+        }
+
+        // ASSEMBLE TRACTIONS
+        {
+            for (Integer i = 0; i<nodeperelem; ++i) {
+                UInteger T_idx = elements[elem*nodeperelem+i]*nvar;
+                for (Integer iterator = 0; iterator < nvar; ++iterator) {
+                    T[T_idx+iterator] += traction[i*nvar+iterator];
+                }
+            }
+        }
+
+    }
+
+    deallocate(current_Jm);
+    deallocate(LagrangeElemCoords);
+    deallocate(EulerElemCoords);
+    deallocate(ElectricPotentialElem);
+    deallocate(MaterialGradient);
+    deallocate(SpatialGradient);
+    deallocate(local_traction);
+    deallocate(traction);
+}
+
+
+
+
+
+
+
+
+
+
+void _GlobalAssemblyExplicit_DF_DPF_(const Real *points,
+                        const UInteger* elements,
+                        const Real* Eulerx,
+                        const Real* Eulerp,
+                        const Real* bases,
+                        const Real* Jm,
+                        const Real* AllGauss,
+                        Integer ndim,
+                        Integer nvar,
+                        Integer ngauss,
+                        Integer nelem,
+                        Integer nodeperelem,
+                        Integer nnode,
+                        Integer H_VoigtSize,
+                        Integer requires_geometry_update,
+                        Real *T,
+                        Integer is_dynamic,
+                        Integer* local_rows_mass,
+                        Integer* local_cols_mass,
+                        int *I_mass,
+                        int *J_mass,
+                        Real *V_mass,
+                        Real rho,
+                        Real mu,
+                        Real mu1,
+                        Real mu2,
+                        Real mu3,
+                        Real mue,
+                        Real lamb,
+                        Real eps_1,
+                        Real eps_2,
+                        Real eps_3,
+                        Real eps_e,
+                        const Real *anisotropic_orientations,
+                        int material_number,
+                        int formulation_number
+                        ) {
+
+    if (ndim==3) {
+        _GlobalAssemblyExplicit_DF_DPF_<3>(points,
+                        elements,
+                        Eulerx,
+                        Eulerp,
+                        bases,
+                        Jm,
+                        AllGauss,
+                        nvar,
+                        ngauss,
+                        nelem,
+                        nodeperelem,
+                        nnode,
+                        H_VoigtSize,
+                        requires_geometry_update,
+                        T,
+                        mu,
+                        mu1,
+                        mu2,
+                        mu3,
+                        mue,
+                        lamb,
+                        eps_1,
+                        eps_2,
+                        eps_3,
+                        eps_e,
+                        anisotropic_orientations,
+                        material_number,
+                        formulation_number
+                        );
+    }
+    else {
+
+        _GlobalAssemblyExplicit_DF_DPF_<2>(points,
+                        elements,
+                        Eulerx,
+                        Eulerp,
+                        bases,
+                        Jm,
+                        AllGauss,
+                        nvar,
+                        ngauss,
+                        nelem,
+                        nodeperelem,
+                        nnode,
+                        H_VoigtSize,
+                        requires_geometry_update,
+                        T,
+                        mu,
+                        mu1,
+                        mu2,
+                        mu3,
+                        mue,
+                        lamb,
+                        eps_1,
+                        eps_2,
+                        eps_3,
+                        eps_e,
+                        anisotropic_orientations,
+                        material_number,
+                        formulation_number
+                        );
+
+    }
+}
+
+
+
+
+
+#else
+
+
+
+
+
+// COMPATIBLE TO ASSEMBLY FOR IMPLICIT ROUTINES - WELL TESTED
 void _GlobalAssemblyExplicit_DF_DPF_(const Real *points,
                         const UInteger* elements,
                         const Real* Eulerx,
@@ -299,6 +926,8 @@ void _GlobalAssemblyExplicit_DF_DPF_(const Real *points,
 
 }
 
+#endif
+
 
 #endif // _LOWLEVELASSEMBLYDPF__H
 
@@ -309,7 +938,7 @@ void _GlobalAssemblyExplicit_DF_DPF_(const Real *points,
 
 
 
-// ORIGINAL NON-UNROLLED VERSION
+// TWO GENERATION ORIGINAL NON-UNROLLED VERSION
 
 
 // #ifndef _LOWLEVELASSEMBLYDPF__H

--- a/Florence/Tensor/_matmul_.h
+++ b/Florence/Tensor/_matmul_.h
@@ -151,10 +151,10 @@ void _matmul_22k(size_t N, const T* FASTOR_RESTRICT a, const T* FASTOR_RESTRICT 
     using V128 = SIMDVector<T,128>;
     constexpr size_t M = 2;
 
-    constexpr int SIZE_AVX = V256::Size;
-    constexpr int SIZE_SSE = V128::Size;
-    const int ROUND_AVX = ROUND_DOWN(N,(int)SIZE_AVX);
-    const int ROUND_SSE = ROUND_DOWN(N,(int)SIZE_SSE);
+    constexpr size_t SIZE_AVX = V256::Size;
+    constexpr size_t SIZE_SSE = V128::Size;
+    const size_t ROUND_AVX = ROUND_DOWN(N,SIZE_AVX);
+    const size_t ROUND_SSE = ROUND_DOWN(N,SIZE_SSE);
 
     size_t k=0;
     for (; k<ROUND_AVX; k+=SIZE_AVX) {
@@ -217,10 +217,10 @@ void _matmul_33k(size_t N, const T* FASTOR_RESTRICT a, const T* FASTOR_RESTRICT 
     using V128 = SIMDVector<T,128>;
     constexpr size_t M = 3;
 
-    constexpr int SIZE_AVX = V256::Size;
-    constexpr int SIZE_SSE = V128::Size;
-    const int ROUND_AVX = ROUND_DOWN(N,(int)SIZE_AVX);
-    const int ROUND_SSE = ROUND_DOWN(N,(int)SIZE_SSE);
+    constexpr size_t SIZE_AVX = V256::Size;
+    constexpr size_t SIZE_SSE = V128::Size;
+    const size_t ROUND_AVX = ROUND_DOWN(N,SIZE_AVX);
+    const size_t ROUND_SSE = ROUND_DOWN(N,SIZE_SSE);
 
     size_t k=0;
     for (; k<ROUND_AVX; k+=SIZE_AVX) {
@@ -315,10 +315,10 @@ void _matmul_(size_t M, size_t N, size_t K, const T * FASTOR_RESTRICT a, const T
     using V256 = SIMDVector<T,256>;
     using V128 = SIMDVector<T,128>;
 
-    constexpr int SIZE_AVX = V256::Size;
-    constexpr int SIZE_SSE = V128::Size;
-    const int ROUND_AVX = ROUND_DOWN(N,(int)SIZE_AVX);
-    const int ROUND_SSE = ROUND_DOWN(N,(int)SIZE_SSE);
+    constexpr size_t SIZE_AVX = V256::Size;
+    constexpr size_t SIZE_SSE = V128::Size;
+    const size_t ROUND_AVX = ROUND_DOWN(N,SIZE_AVX);
+    const size_t ROUND_SSE = ROUND_DOWN(N,SIZE_SSE);
 
     for (size_t j=0; j<M; ++j) {
         size_t k=0;

--- a/setup.py
+++ b/setup.py
@@ -360,8 +360,6 @@ class FlorenceSetup(object):
                     material = material.lstrip('_').rstrip('_')
                     execute('cd '+_path+' && make ' + self.compiler_args + " MATERIAL=" + material)
             elif "_Assembly_" in _path:
-                execute('cd '+_path+' && python AOT_Assembler.py clean')
-                execute('cd '+_path+' && python AOT_Assembler.py configure')
 
                 ll_material_mech = low_level_material_list[:4]
                 ll_material_electro_mech = low_level_material_list[4:]
@@ -371,6 +369,10 @@ class FlorenceSetup(object):
                 # ll_material_electro_mech = low_level_material_list
                 # ll_material_mech = low_level_material_list
                 # ll_material_electro_mech = []
+
+                execute('cd '+_path+' && python AOT_Assembler.py clean')
+                execute('cd '+_path+' && python AOT_Assembler.py configure')
+
                 for material in ll_material_mech:
                     execute('cd '+_path+' && make ' + self.compiler_args + " ASSEMBLY_NAME=_LowLevelAssemblyDF_"  + material)
                 for material in ll_material_electro_mech:


### PR DESCRIPTION
A much faster self-contained reimplementation of low level routines for explicit (only RHS) assembly:

- avoiding high order tensors
- decreasing number of mallocs by making arrays static (such as F, D, stress)
- zero elimination in BDT (i.e. matrix-vector multiplication for tractions)
- bug fix for signed and unsigned comparisons in `_matmul_` functions
- force alignment for new and old static arrays

For small problems (2D p/q=1) this version is much faster. For 3D high p/q problems the gain is typically over 2X. A constant gain of 2.2X is observed in assembly speed all across